### PR TITLE
indexOf calling with single char string

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v2/ImageImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v2/ImageImpl.java
@@ -155,7 +155,7 @@ public class ImageImpl extends com.adobe.cq.wcm.core.components.internal.models.
             // Parse the image map areas as defined at {@code Image.PN_MAP}
             String[] mapAreas = StringUtils.split(mapProperty, "][");
             for (String area : mapAreas) {
-                int coordinatesEndIndex = area.indexOf(")");
+                int coordinatesEndIndex = area.indexOf(')');
                 if (coordinatesEndIndex < 0) {
                     break;
                 }


### PR DESCRIPTION
An indexOf or lastIndexOf call with a single letter String can be made more performant by switching to a call with a char argument.