### PR TITLE
An indexOf or lastIndexOf call with a single letter String can be mad…

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/PageImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/PageImpl.java
@@ -136,7 +136,7 @@ public class PageImpl implements Page {
         String templateName = null;
         String templatePath = pageProperties.get(NameConstants.PN_TEMPLATE, String.class);
         if (StringUtils.isNotEmpty(templatePath)) {
-            int i = templatePath.lastIndexOf("/");
+            int i = templatePath.lastIndexOf('/');
             if (i > 0) {
                 templateName = templatePath.substring(i + 1);
             }


### PR DESCRIPTION
…e more performant by switching to a call with a char argument.


| ------------------------ | ---
| Fixed Issues?            | An indexOf or lastIndexOf call with a single letter String
| Patch: Bug Fix?          |
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes 
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

An indexOf or lastIndexOf call with a single letter String can be made more performant by switching to a call with a char argument.
