### PR TITLE
Unnecessary imports should be removed

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/form/FormStructureHelperImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/form/FormStructureHelperImpl.java
@@ -21,7 +21,6 @@ import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.resource.ModifiableValueMap;
-import org.apache.sling.api.resource.PersistenceException;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ValueMap;

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/jackson/DefaultMethodSkippingModuleProvider.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/jackson/DefaultMethodSkippingModuleProvider.java
@@ -27,7 +27,6 @@ import org.osgi.service.component.annotations.Component;
 
 import java.lang.reflect.Member;
 import java.lang.reflect.Method;
-import java.lang.NoSuchMethodException;
 import java.util.List;
 import java.util.stream.Collectors;
 


### PR DESCRIPTION
The imports part of a file should be handled by the Integrated Development Environment (IDE), not manually by the developer.
Unused and useless imports should not occur if that is the case.
Leaving them in reduces the code's readability, since their presence can be confusing.