### PR TITLE
Null pointers should not be dereferenced

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/commons/editor/dialog/childreneditor/Editor.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/commons/editor/dialog/childreneditor/Editor.java
@@ -62,11 +62,13 @@ public class Editor {
             container = resolver.getResource(containerPath);
             if (container != null) {
                 ComponentManager componentManager = request.getResourceResolver().adaptTo(ComponentManager.class);
-                for (Resource resource : container.getChildren()) {
-                    if (resource != null) {
-                        Component component = componentManager.getComponentOfResource(resource);
-                        if (component != null) {
-                            items.add(new Item(request, resource));
+                if(componentManager != null){
+                    for (Resource resource : container.getChildren()) {
+                        if (resource != null) {
+                            Component component = componentManager.getComponentOfResource(resource);
+                            if (component != null) {
+                                items.add(new Item(request, resource));
+                            }
                         }
                     }
                 }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServlet.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServlet.java
@@ -470,7 +470,7 @@ public class AdaptiveImageServlet extends SlingSafeMethodsServlet {
         String csv = properties.get(ImageResource.PN_IMAGE_CROP, String.class);
         if (StringUtils.isNotEmpty(csv)) {
             try {
-                int ratio = csv.indexOf("/");
+                int ratio = csv.indexOf('/');
                 if (ratio >= 0) {
                     // skip ratio
                     csv = csv.substring(0, ratio);

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/AllowedColorSwatchesDataSourceServlet.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/AllowedColorSwatchesDataSourceServlet.java
@@ -18,7 +18,6 @@ package com.adobe.cq.wcm.core.components.internal.servlets;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 
 import javax.servlet.Servlet;

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/CoreFormHandlingServlet.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/CoreFormHandlingServlet.java
@@ -110,6 +110,7 @@ public class CoreFormHandlingServlet
     /**
      * @see org.apache.sling.api.servlets.SlingAllMethodsServlet#doPost(org.apache.sling.api.SlingHttpServletRequest, org.apache.sling.api.SlingHttpServletResponse)
      */
+    @Override
     protected void doPost(SlingHttpServletRequest request,
                           final SlingHttpServletResponse response)
             throws ServletException, IOException {


### PR DESCRIPTION
A reference to null should never be dereferenced/accessed. Doing so will cause a NullPointerException to be thrown. At best, such an exception will cause abrupt program termination. At worst, it could expose debugging information that would be useful to an attacker, or it could allow an attacker to bypass security measures